### PR TITLE
Fix --shell erroring Popen on Windows

### DIFF
--- a/cram/_main.py
+++ b/cram/_main.py
@@ -22,7 +22,11 @@ def _which(cmd):
     for p in os.environ['PATH'].split(os.pathsep):
         path = os.path.join(os.fsencode(p), cmd)
         if os.path.isfile(path) and os.access(path, os.X_OK):
-            return os.path.abspath(path)
+            if os.supports_bytes_environ:
+                return os.path.abspath(path)
+            else:
+                # subprocess.Popen requires env to by Dict[str,str] on Windows
+                return os.path.abspath(path).decode()
     return None
 
 def _expandpath(path):


### PR DESCRIPTION
On Windows, running cram with --shell set causes a `TypeError: environment can only contain strings` as follows:

```bash
(.venv) λ python -m cram tests\my-test.t --shell="C:\Windows\System32\bash.exe"
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "c:\temp\myproject\.venv\Lib\site-packages\cram\__main__.py", line 8, in <module>
    sys.exit(cram.main(sys.argv[1:]))
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\temp\myproject\.venv\Lib\site-packages\cram\_main.py", line 200, in main
    refout, postout, diff = test()
                            ^^^^^^
  File "c:\temp\myproject\.venv\Lib\site-packages\cram\_cli.py", line 83, in testwrapper
    refout, postout, diff = test()
                            ^^^^^^
  File "c:\temp\myproject\.venv\Lib\site-packages\cram\_run.py", line 71, in test
    return testfile(abspath, shell, indent=indent,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\temp\myproject\.venv\Lib\site-packages\cram\_test.py", line 234, in testfile
    return test(f, shell, indent=indent, testname=testname, env=env,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\temp\myproject\.venv\Lib\site-packages\cram\_test.py", line 153, in test
    output, retcode = execute(shell + ['-'], stdin=b('').join(stdin),
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\temp\myproject\.venv\Lib\site-packages\cram\_process.py", line 49, in execute
    p = subprocess.Popen(args, stdin=PIPE, stdout=stdout, stderr=stderr,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python311\Lib\subprocess.py", line 1022, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "C:\Program Files\Python311\Lib\subprocess.py", line 1491, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: environment can only contain strings
```

This is because cram forces the --shell argument into a bytes object in `_where()`, but `subprocess.Popen()` requires `env` to be a mapping of str to str on Windows systems (according to https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module)

This fix works on my system, and will only affect systems where this is the requirement.